### PR TITLE
scroll-dev: ceno-recursion-verifier

### DIFF
--- a/extensions/native/compiler/src/asm/compiler.rs
+++ b/extensions/native/compiler/src/asm/compiler.rs
@@ -617,6 +617,15 @@ impl<F: PrimeField32 + TwoAdicField, EF: ExtensionField<F> + TwoAdicField> AsmCo
                         debug_info,
                     );
                 }
+                DslIr::ExtFromBaseVec(ext, base_vec) => {
+                    assert_eq!(base_vec.len(), EF::D);
+                    for (i, base) in base_vec.into_iter().enumerate() {
+                        self.push(
+                            AsmInstruction::CopyF(ext.fp() + (i as i32), base.fp()),
+                            debug_info.clone(),
+                        );
+                    }
+                }
                 _ => unimplemented!(),
             }
         }

--- a/extensions/native/compiler/src/ir/builder.rs
+++ b/extensions/native/compiler/src/ir/builder.rs
@@ -620,6 +620,10 @@ impl<C: Config> Builder<C> {
         self.witness_space.get(id.value()).unwrap()
     }
 
+    pub fn ext_from_base_vec(&mut self, ext: Ext<C::F, C::EF>, base_vec: Vec<Felt<C::F>>) {
+        self.push(DslIr::ExtFromBaseVec(ext, base_vec));
+    }
+
     /// Throws an error.
     pub fn error(&mut self) {
         self.operations.trace_push(DslIr::Error());

--- a/extensions/native/compiler/src/ir/instructions.rs
+++ b/extensions/native/compiler/src/ir/instructions.rs
@@ -229,6 +229,9 @@ pub enum DslIr<C: Config> {
     /// Operation to halt the program. Should be the last instruction in the program.
     Halt,
 
+    /// Samples an ext from a vector of felts.
+    ExtFromBaseVec(Ext<C::F, C::EF>, Vec<Felt<C::F>>),
+
     // Public inputs for circuits.
     /// Publish a field element as the ith public value. Should only be used when target is a circuit.
     CircuitPublish(Var<C::N>, usize),

--- a/extensions/native/compiler/src/ir/instructions.rs
+++ b/extensions/native/compiler/src/ir/instructions.rs
@@ -229,7 +229,7 @@ pub enum DslIr<C: Config> {
     /// Operation to halt the program. Should be the last instruction in the program.
     Halt,
 
-    /// Samples an ext from a vector of felts.
+    /// Packs a vector of felts into an ext.
     ExtFromBaseVec(Ext<C::F, C::EF>, Vec<Felt<C::F>>),
 
     // Public inputs for circuits.

--- a/extensions/native/compiler/tests/ext.rs
+++ b/extensions/native/compiler/tests/ext.rs
@@ -35,7 +35,7 @@ fn test_ext2felt() {
 }
 
 #[test]
-fn test_ext_from_base_slice() {
+fn test_ext_from_base_vec() {
     const D: usize = 4;
     type F = BabyBear;
     type EF = BinomialExtensionField<BabyBear, D>;
@@ -52,8 +52,9 @@ fn test_ext_from_base_slice() {
     let val = EF::from_base_slice(base_slice);
     let expected: Ext<_, _> = builder.constant(val);
 
-    let felts = base_slice.map(|e| builder.constant::<Felt<_>>(e));
-    let actual = builder.ext_from_base_slice(&felts);
+    let felts = base_slice.map(|e| builder.constant::<Felt<_>>(e)).to_vec();
+    let actual = builder.uninit();
+    builder.ext_from_base_vec(actual, felts);
     builder.assert_ext_eq(actual, expected);
 
     builder.halt();

--- a/extensions/native/recursion/src/challenger/duplex.rs
+++ b/extensions/native/recursion/src/challenger/duplex.rs
@@ -101,7 +101,9 @@ impl<C: Config> DuplexChallengerVariable<C> {
         let b = self.sample(builder);
         let c = self.sample(builder);
         let d = self.sample(builder);
-        builder.ext_from_base_slice(&[a, b, c, d])
+        let ext = builder.uninit();
+        builder.ext_from_base_vec(ext, vec![a, b, c, d]);
+        ext
     }
 
     fn sample_bits(&self, builder: &mut Builder<C>, nb_bits: RVar<C::N>) -> Array<C, Var<C::N>>


### PR DESCRIPTION
## Changelog

against https://github.com/openvm-org/openvm/releases/tag/v1.0.0

- Rewrite `sample_ext`
https://github.com/openvm-org/openvm/commit/03827f1f69b19c51f440af0b6944f77ce61e7390
We add a new IR instruction `DslIr::ExtFromBaseVec` that uses the `AsmInstruction::CopyF` internally, to reduce the number of cycles introduced by `sample_ext` that used the `SymbolicExt` expression approach before.
- ...