### PR TITLE
Reduce Context Operations in Native Sumcheck

### DIFF
--- a/extensions/native/circuit/cuda/include/native/sumcheck.cuh
+++ b/extensions/native/circuit/cuda/include/native/sumcheck.cuh
@@ -8,14 +8,14 @@ using namespace native;
 template <typename T> struct HeaderSpecificCols {
     T pc;
     T registers[5];
-    MemoryReadAuxCols<T> read_records[7];
+    MemoryReadAuxCols<T> read_records[8];
     MemoryWriteAuxCols<T, EXT_DEG> write_records;
 };
 
 template <typename T> struct ProdSpecificCols {
     T data_ptr;
     T p[EXT_DEG * 2];
-    MemoryReadAuxCols<T> read_records[2];
+    MemoryReadAuxCols<T> read_records[1];
     T p_evals[EXT_DEG];
     MemoryWriteAuxCols<T, EXT_DEG> write_record;
     T eval_rlc[EXT_DEG];
@@ -24,7 +24,7 @@ template <typename T> struct ProdSpecificCols {
 template <typename T> struct LogupSpecificCols {
     T data_ptr;
     T pq[EXT_DEG * 4];
-    MemoryReadAuxCols<T> read_records[2];
+    MemoryReadAuxCols<T> read_records[1];
     T p_evals[EXT_DEG];
     T q_evals[EXT_DEG];
     MemoryWriteAuxCols<T, EXT_DEG> write_records[2];

--- a/extensions/native/circuit/cuda/src/sumcheck.cu
+++ b/extensions/native/circuit/cuda/src/sumcheck.cu
@@ -11,7 +11,7 @@ __device__ void fill_sumcheck_specific(RowSlice row, MemoryAuxColsFactory &mem_h
     uint32_t start_timestamp = row[COL_INDEX(NativeSumcheckCols, start_timestamp)].asUInt32();
 
     if (row[COL_INDEX(NativeSumcheckCols, header_row)] == Fp::one()) {
-        for (uint32_t i = 0; i < 7; ++i) {
+        for (uint32_t i = 0; i < 8; ++i) {
             mem_fill_base(
                 mem_helper,
                 start_timestamp + i,
@@ -25,43 +25,33 @@ __device__ void fill_sumcheck_specific(RowSlice row, MemoryAuxColsFactory &mem_h
             specific.slice_from(COL_INDEX(HeaderSpecificCols, write_records.base))
         );
     } else if (row[COL_INDEX(NativeSumcheckCols, prod_row)] == Fp::one()) {
-        mem_fill_base(
-            mem_helper,
-            start_timestamp,
-            specific.slice_from(COL_INDEX(ProdSpecificCols, read_records[0].base))
-        );
         if (row[COL_INDEX(NativeSumcheckCols, within_round_limit)] == Fp::one()) {
             mem_fill_base(
                 mem_helper,
-                start_timestamp + 1,
-                specific.slice_from(COL_INDEX(ProdSpecificCols, read_records[1].base))
+                start_timestamp,
+                specific.slice_from(COL_INDEX(ProdSpecificCols, read_records[0].base))
             );
             mem_fill_base(
                 mem_helper,
-                start_timestamp + 2,
+                start_timestamp + 1,
                 specific.slice_from(COL_INDEX(ProdSpecificCols, write_record.base))
             );
         }
     } else if (row[COL_INDEX(NativeSumcheckCols, logup_row)] == Fp::one()) {
-        mem_fill_base(
-            mem_helper,
-            start_timestamp,
-            specific.slice_from(COL_INDEX(LogupSpecificCols, read_records[0].base))
-        );
         if (row[COL_INDEX(NativeSumcheckCols, within_round_limit)] == Fp::one()) {
             mem_fill_base(
                 mem_helper,
-                start_timestamp + 1,
-                specific.slice_from(COL_INDEX(LogupSpecificCols, read_records[1].base))
+                start_timestamp,
+                specific.slice_from(COL_INDEX(LogupSpecificCols, read_records[0].base))
             );
             mem_fill_base(
                 mem_helper,
-                start_timestamp + 2,
+                start_timestamp + 1,
                 specific.slice_from(COL_INDEX(LogupSpecificCols, write_records[0].base))
             );
             mem_fill_base(
                 mem_helper,
-                start_timestamp + 3,
+                start_timestamp + 2,
                 specific.slice_from(COL_INDEX(LogupSpecificCols, write_records[1].base))
             );
         }

--- a/extensions/native/circuit/src/sumcheck/air.rs
+++ b/extensions/native/circuit/src/sumcheck/air.rs
@@ -330,6 +330,16 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
             )
             .eval(builder, header_row);
 
+        // Read max_round
+        self.memory_bridge
+            .read(
+                MemoryAddress::new(native_as, register_ptrs[0]),
+                [max_round],
+                first_timestamp + AB::F::from_canonical_usize(7),
+                &header_row_specific.read_records[7],
+            )
+            .eval(builder, header_row);
+
         // Write final result
         self.memory_bridge
             .write(
@@ -347,20 +357,6 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
             specific[..ProdSpecificCols::<AB::Var>::width()].borrow();
         let next_prod_row_specific: &ProdSpecificCols<AB::Var> =
             next.specific[..ProdSpecificCols::<AB::Var>::width()].borrow();
-
-        self.memory_bridge
-            .read(
-                MemoryAddress::new(
-                    native_as,
-                    register_ptrs[0]
-                        + AB::F::from_canonical_usize(CONTEXT_ARR_BASE_LEN)
-                        + (curr_prod_n - AB::F::ONE),
-                ), // curr_prod_n starts at 1.
-                [max_round],
-                start_timestamp,
-                &prod_row_specific.read_records[0],
-            )
-            .eval(builder, prod_row);
 
         // prod_row * within_round_limit =
         //    prod_in_round_evaluation + prod_next_round_evaluation
@@ -385,8 +381,8 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
             .read(
                 MemoryAddress::new(native_as, register_ptrs[2] + prod_row_specific.data_ptr),
                 prod_row_specific.p,
-                start_timestamp + AB::F::ONE,
-                &prod_row_specific.read_records[1],
+                start_timestamp,
+                &prod_row_specific.read_records[0],
             )
             .eval(builder, prod_row * within_round_limit);
 
@@ -402,7 +398,7 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
                     register_ptrs[4] + curr_prod_n * AB::F::from_canonical_usize(EXT_DEG),
                 ),
                 prod_row_specific.p_evals,
-                start_timestamp + AB::F::TWO,
+                start_timestamp + AB::F::ONE,
                 &prod_row_specific.write_record,
             )
             .eval(builder, prod_row * within_round_limit);
@@ -449,21 +445,6 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
         let next_logup_row_specfic: &LogupSpecificCols<AB::Var> =
             next.specific[..LogupSpecificCols::<AB::Var>::width()].borrow();
 
-        self.memory_bridge
-            .read(
-                MemoryAddress::new(
-                    native_as,
-                    register_ptrs[0]
-                        + AB::F::from_canonical_usize(EXT_DEG * 2)
-                        + num_prod_spec
-                        + (curr_logup_n - AB::F::ONE),
-                ), // curr_logup_n starts at 1.
-                [max_round],
-                start_timestamp,
-                &logup_row_specific.read_records[0],
-            )
-            .eval(builder, logup_row);
-
         // logup_row * within_round_limit =
         //    logup_in_round_evaluation + logup_next_round_evaluation
         builder
@@ -488,8 +469,8 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
             .read(
                 MemoryAddress::new(native_as, register_ptrs[3] + logup_row_specific.data_ptr),
                 logup_row_specific.pq,
-                start_timestamp + AB::F::ONE,
-                &logup_row_specific.read_records[1],
+                start_timestamp,
+                &logup_row_specific.read_records[0],
             )
             .eval(builder, logup_row * within_round_limit);
 
@@ -513,7 +494,7 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
                         + (num_prod_spec + curr_logup_n) * AB::F::from_canonical_usize(EXT_DEG),
                 ),
                 logup_row_specific.p_evals,
-                start_timestamp + AB::F::TWO,
+                start_timestamp + AB::F::ONE,
                 &logup_row_specific.write_records[0],
             )
             .eval(builder, logup_row * within_round_limit);
@@ -528,7 +509,7 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
                             * AB::F::from_canonical_usize(EXT_DEG),
                 ),
                 logup_row_specific.q_evals,
-                start_timestamp + AB::F::from_canonical_usize(3),
+                start_timestamp + AB::F::TWO,
                 &logup_row_specific.write_records[1],
             )
             .eval(builder, logup_row * within_round_limit);

--- a/extensions/native/circuit/src/sumcheck/air.rs
+++ b/extensions/native/circuit/src/sumcheck/air.rs
@@ -169,6 +169,9 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
         );
         builder
             .when(next.prod_row + next.logup_row)
+            .assert_eq(max_round, next.max_round);
+        builder
+            .when(next.prod_row + next.logup_row)
             .assert_eq(prod_nested_len, next.prod_nested_len);
         builder
             .when(next.prod_row + next.logup_row)
@@ -223,21 +226,21 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
             .when(next.prod_row + next.logup_row)
             .assert_eq(
                 next.start_timestamp,
-                start_timestamp + AB::F::from_canonical_usize(7),
+                start_timestamp + AB::F::from_canonical_usize(8),
             );
         builder
             .when(prod_row)
             .when(next.prod_row + next.logup_row)
             .assert_eq(
                 next.start_timestamp,
-                start_timestamp + AB::F::ONE + within_round_limit * AB::F::TWO,
+                start_timestamp + within_round_limit * AB::F::TWO,
             );
         builder
             .when(logup_row)
             .when(next.prod_row + next.logup_row)
             .assert_eq(
                 next.start_timestamp,
-                start_timestamp + AB::F::ONE + within_round_limit * AB::F::from_canonical_usize(3),
+                start_timestamp + within_round_limit * AB::F::from_canonical_usize(3),
             );
 
         // Termination condition
@@ -333,7 +336,10 @@ impl<AB: InteractionBuilder> Air<AB> for NativeSumcheckAir {
         // Read max_round
         self.memory_bridge
             .read(
-                MemoryAddress::new(native_as, register_ptrs[0]),
+                MemoryAddress::new(
+                    native_as,
+                    register_ptrs[0] + AB::F::from_canonical_usize(CONTEXT_ARR_BASE_LEN),
+                ),
                 [max_round],
                 first_timestamp + AB::F::from_canonical_usize(7),
                 &header_row_specific.read_records[7],

--- a/extensions/native/circuit/src/sumcheck/chip.rs
+++ b/extensions/native/circuit/src/sumcheck/chip.rs
@@ -209,8 +209,8 @@ where
         );
         let [max_round]: [F; 1] = tracing_read_native_helper(
             state.memory,
-            ctx_ptr.as_canonical_u32() + CONTEXT_ARR_BASE_LEN as u32, 
-            head_specific.read_records[7].as_mut()
+            ctx_ptr.as_canonical_u32() + CONTEXT_ARR_BASE_LEN as u32,
+            head_specific.read_records[7].as_mut(),
         );
         cur_timestamp += 8; // 5 register reads + ctx read + challenges read + max_round read
         head_row.challenges.copy_from_slice(&challenges);

--- a/extensions/native/circuit/src/sumcheck/chip.rs
+++ b/extensions/native/circuit/src/sumcheck/chip.rs
@@ -144,7 +144,6 @@ where
         let [ctx_ptr]: [F; 1] = memory_read_native(state.memory.data(), ctx_reg.as_canonical_u32());
         let ctx: [u32; 8] = memory_read_native(state.memory.data(), ctx_ptr.as_canonical_u32())
             .map(|x: F| x.as_canonical_u32());
-
         let [round, num_prod_spec, num_logup_spec, prod_specs_inner_len, prod_specs_inner_inner_len, logup_specs_inner_len, logup_specs_inner_inner_len, mode] =
             ctx;
         // allocate n rows
@@ -198,19 +197,22 @@ where
             r_evals_reg.as_canonical_u32(),
             head_specific.read_records[4].as_mut(),
         );
-
         let ctx: [F; CONTEXT_ARR_BASE_LEN] = tracing_read_native_helper(
             state.memory,
             ctx_ptr.as_canonical_u32(),
             head_specific.read_records[5].as_mut(),
         );
-
         let challenges: [F; EXT_DEG * 4] = tracing_read_native_helper(
             state.memory,
             challenges_ptr.as_canonical_u32(),
             head_specific.read_records[6].as_mut(),
         );
-        cur_timestamp += 7; // 5 register reads + ctx read + challenges read
+        let [max_round]: [F; 1] = tracing_read_native_helper(
+            state.memory,
+            ctx_ptr.as_canonical_u32() + CONTEXT_ARR_BASE_LEN as u32, 
+            head_specific.read_records[7].as_mut()
+        );
+        cur_timestamp += 8; // 5 register reads + ctx read + challenges read + max_round read
         head_row.challenges.copy_from_slice(&challenges);
 
         // challenges = [alpha, c1=r, c2=1-r]
@@ -221,7 +223,7 @@ where
         let mut eval_acc = elem_to_ext(F::from_canonical_u32(0));
         let mut alpha_acc = elem_to_ext(F::from_canonical_u32(1));
 
-        // all rows share same register values, ctx, challenges
+        // all rows share same register values, ctx, challenges, max_round
         for row in rows.iter_mut() {
             // c1, c2 are same during the entire execution
             row.challenges[EXT_DEG..3 * EXT_DEG].copy_from_slice(&challenges[EXT_DEG..3 * EXT_DEG]);
@@ -236,6 +238,7 @@ where
             row.register_ptrs[2] = prod_evals_ptr;
             row.register_ptrs[3] = logup_evals_ptr;
             row.register_ptrs[4] = r_evals_ptr;
+            row.max_round = max_round;
         }
 
         // product rows
@@ -256,15 +259,6 @@ where
             };
             prod_row.curr_prod_n = F::from_canonical_usize(i + 1); // curr_prod_n starts from 1
             prod_row.start_timestamp = F::from_canonical_u32(cur_timestamp);
-
-            // read max_round
-            let [max_round]: [F; 1] = tracing_read_native_helper(
-                state.memory,
-                ctx_ptr.as_canonical_u32() + (CONTEXT_ARR_BASE_LEN + i) as u32,
-                prod_specific.read_records[0].as_mut(),
-            );
-            cur_timestamp += 1;
-
             prod_row.challenges[0..EXT_DEG].copy_from_slice(&alpha_acc);
             prod_row.max_round = max_round;
 
@@ -285,7 +279,7 @@ where
                 let ps: [F; EXT_DEG * 2] = tracing_read_native_helper(
                     state.memory,
                     prod_evals_ptr.as_canonical_u32() + start,
-                    prod_specific.read_records[1].as_mut(),
+                    prod_specific.read_records[0].as_mut(),
                 );
                 let p1: [F; EXT_DEG] = ps[0..EXT_DEG].try_into().unwrap();
                 let p2: [F; EXT_DEG] = ps[EXT_DEG..(EXT_DEG * 2)].try_into().unwrap();
@@ -350,15 +344,7 @@ where
             };
             logup_row.curr_logup_n = F::from_canonical_usize(i + 1); // curr_logup_n starts from 1
             logup_row.start_timestamp = F::from_canonical_u32(cur_timestamp);
-
-            let [max_round]: [F; 1] = tracing_read_native_helper(
-                state.memory,
-                ctx_ptr.as_canonical_u32() + num_prod_spec + (CONTEXT_ARR_BASE_LEN + i) as u32,
-                logup_specific.read_records[0].as_mut(),
-            );
             logup_row.max_round = max_round;
-            cur_timestamp += 1;
-
             let alpha_numerator = alpha_acc;
             let alpha_denominator = FieldExtension::multiply(alpha_acc, alpha);
             logup_row.challenges[0..EXT_DEG].copy_from_slice(&alpha_acc);
@@ -380,7 +366,7 @@ where
                 let pqs: [F; EXT_DEG * 4] = tracing_read_native_helper(
                     state.memory,
                     logup_evals_ptr.as_canonical_u32() + start,
-                    logup_specific.read_records[1].as_mut(),
+                    logup_specific.read_records[0].as_mut(),
                 );
                 let p1: [F; EXT_DEG] = pqs[0..EXT_DEG].try_into().unwrap();
                 let p2: [F; EXT_DEG] = pqs[EXT_DEG..(EXT_DEG * 2)].try_into().unwrap();
@@ -545,7 +531,7 @@ impl<F: PrimeField32> TraceFiller<F> for NativeSumcheckFiller {
                 mem_fill_helper(
                     mem_helper,
                     start_timestamp + 1,
-                    prod_row_specific.read_records[1].as_mut(),
+                    prod_row_specific.read_records[0].as_mut(),
                 );
                 // write p_eval
                 mem_fill_helper(
@@ -569,7 +555,7 @@ impl<F: PrimeField32> TraceFiller<F> for NativeSumcheckFiller {
                 mem_fill_helper(
                     mem_helper,
                     start_timestamp + 1,
-                    logup_row_specific.read_records[1].as_mut(),
+                    logup_row_specific.read_records[0].as_mut(),
                 );
                 // write p_eval
                 mem_fill_helper(

--- a/extensions/native/circuit/src/sumcheck/chip.rs
+++ b/extensions/native/circuit/src/sumcheck/chip.rs
@@ -260,7 +260,6 @@ where
             prod_row.curr_prod_n = F::from_canonical_usize(i + 1); // curr_prod_n starts from 1
             prod_row.start_timestamp = F::from_canonical_u32(cur_timestamp);
             prod_row.challenges[0..EXT_DEG].copy_from_slice(&alpha_acc);
-            prod_row.max_round = max_round;
 
             let max_round = max_round.as_canonical_u32();
             // round starts from 0
@@ -344,7 +343,6 @@ where
             };
             logup_row.curr_logup_n = F::from_canonical_usize(i + 1); // curr_logup_n starts from 1
             logup_row.start_timestamp = F::from_canonical_u32(cur_timestamp);
-            logup_row.max_round = max_round;
             let alpha_numerator = alpha_acc;
             let alpha_denominator = FieldExtension::multiply(alpha_acc, alpha);
             logup_row.challenges[0..EXT_DEG].copy_from_slice(&alpha_acc);
@@ -504,7 +502,7 @@ impl<F: PrimeField32> TraceFiller<F> for NativeSumcheckFiller {
             let header: &mut HeaderSpecificCols<F> =
                 cols.specific[..HeaderSpecificCols::<F>::width()].borrow_mut();
 
-            for i in 0..7usize {
+            for i in 0..8usize {
                 mem_fill_helper(
                     mem_helper,
                     start_timestamp + i as u32,
@@ -520,23 +518,17 @@ impl<F: PrimeField32> TraceFiller<F> for NativeSumcheckFiller {
             let prod_row_specific: &mut ProdSpecificCols<F> =
                 cols.specific[..ProdSpecificCols::<F>::width()].borrow_mut();
 
-            // read max_round
-            mem_fill_helper(
-                mem_helper,
-                start_timestamp,
-                prod_row_specific.read_records[0].as_mut(),
-            );
             if cols.within_round_limit == F::ONE {
                 // read p1, p2
                 mem_fill_helper(
                     mem_helper,
-                    start_timestamp + 1,
+                    start_timestamp,
                     prod_row_specific.read_records[0].as_mut(),
                 );
                 // write p_eval
                 mem_fill_helper(
                     mem_helper,
-                    start_timestamp + 2,
+                    start_timestamp + 1,
                     prod_row_specific.write_record.as_mut(),
                 );
             }
@@ -544,29 +536,23 @@ impl<F: PrimeField32> TraceFiller<F> for NativeSumcheckFiller {
             let logup_row_specific: &mut LogupSpecificCols<F> =
                 cols.specific[..LogupSpecificCols::<F>::width()].borrow_mut();
 
-            // read max_round
-            mem_fill_helper(
-                mem_helper,
-                start_timestamp,
-                logup_row_specific.read_records[0].as_mut(),
-            );
             if cols.within_round_limit == F::ONE {
                 // read p1, p2, q1, q2
                 mem_fill_helper(
                     mem_helper,
-                    start_timestamp + 1,
+                    start_timestamp,
                     logup_row_specific.read_records[0].as_mut(),
                 );
                 // write p_eval
                 mem_fill_helper(
                     mem_helper,
-                    start_timestamp + 2,
+                    start_timestamp + 1,
                     logup_row_specific.write_records[0].as_mut(),
                 );
                 // write q_eval
                 mem_fill_helper(
                     mem_helper,
-                    start_timestamp + 3,
+                    start_timestamp + 2,
                     logup_row_specific.write_records[1].as_mut(),
                 );
             }

--- a/extensions/native/circuit/src/sumcheck/columns.rs
+++ b/extensions/native/circuit/src/sumcheck/columns.rs
@@ -92,8 +92,8 @@ pub struct NativeSumcheckCols<T> {
 pub struct HeaderSpecificCols<T> {
     pub pc: T,
     pub registers: [T; 5],
-    /// 5 register reads + ctx read + challenges read
-    pub read_records: [MemoryReadAuxCols<T>; 7],
+    /// 5 register reads + ctx read + max round read + challenges read
+    pub read_records: [MemoryReadAuxCols<T>; 8],
     /// Write the final evaluation
     pub write_records: MemoryWriteAuxCols<T, EXT_DEG>,
 }
@@ -105,8 +105,8 @@ pub struct ProdSpecificCols<T> {
     pub data_ptr: T,
     /// 2 extension elements
     pub p: [T; EXT_DEG * 2],
-    /// read max varibale and 2 p values
-    pub read_records: [MemoryReadAuxCols<T>; 2],
+    /// read 2 p values
+    pub read_records: [MemoryReadAuxCols<T>; 1],
     /// Calculated p evals
     pub p_evals: [T; EXT_DEG],
     /// write p_evals
@@ -122,8 +122,8 @@ pub struct LogupSpecificCols<T> {
     pub data_ptr: T,
     /// 4 extension elements
     pub pq: [T; EXT_DEG * 4],
-    /// read max variable and 4 values: p1, p2, q1, q2
-    pub read_records: [MemoryReadAuxCols<T>; 2],
+    /// read 4 values: p1, p2, q1, q2
+    pub read_records: [MemoryReadAuxCols<T>; 1],
     /// Calculated p evals
     pub p_evals: [T; EXT_DEG],
     /// Calculated q evals

--- a/extensions/native/circuit/src/sumcheck/execution.rs
+++ b/extensions/native/circuit/src/sumcheck/execution.rs
@@ -224,7 +224,6 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
     let mut alpha_acc = elem_to_ext(F::ONE);
     let mut eval_acc = elem_to_ext(F::ZERO);
 
-    let prod_offset = ctx_ptr_u32 + CONTEXT_ARR_BASE_LEN as u32;
     for i in 0..num_prod_spec {
         let start = calculate_3d_ext_idx(
             prod_specs_inner_inner_len,
@@ -262,7 +261,6 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
         height += 1;
     }
 
-    let logup_offset = ctx_ptr_u32 + CONTEXT_ARR_BASE_LEN as u32 + num_prod_spec;
     for i in 0..num_logup_spec {
         let start = calculate_3d_ext_idx(
             logup_specs_inner_inner_len,

--- a/extensions/native/circuit/src/sumcheck/execution.rs
+++ b/extensions/native/circuit/src/sumcheck/execution.rs
@@ -214,8 +214,8 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
         ctx;
     let challenges: [F; EXT_DEG * 4] =
         exec_state.vm_read(NATIVE_AS, challenges_ptr.as_canonical_u32());
-    let [max_round]: [u32; 1] = exec_state
-        .vm_read(NATIVE_AS, ctx_ptr_u32 + CONTEXT_ARR_BASE_LEN as u32);
+    let [max_round]: [u32; 1] =
+        exec_state.vm_read(NATIVE_AS, ctx_ptr_u32 + CONTEXT_ARR_BASE_LEN as u32);
     let alpha: [F; EXT_DEG] = challenges[0..EXT_DEG].try_into().unwrap();
     let c1: [F; EXT_DEG] = challenges[EXT_DEG..EXT_DEG * 2].try_into().unwrap();
     let c2: [F; EXT_DEG] = challenges[EXT_DEG * 2..EXT_DEG * 3].try_into().unwrap();

--- a/extensions/native/circuit/src/sumcheck/execution.rs
+++ b/extensions/native/circuit/src/sumcheck/execution.rs
@@ -214,6 +214,8 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
         ctx;
     let challenges: [F; EXT_DEG * 4] =
         exec_state.vm_read(NATIVE_AS, challenges_ptr.as_canonical_u32());
+    let [max_round]: [u32; 1] = exec_state
+        .vm_read(NATIVE_AS, ctx_ptr_u32 + CONTEXT_ARR_BASE_LEN as u32);
     let alpha: [F; EXT_DEG] = challenges[0..EXT_DEG].try_into().unwrap();
     let c1: [F; EXT_DEG] = challenges[EXT_DEG..EXT_DEG * 2].try_into().unwrap();
     let c2: [F; EXT_DEG] = challenges[EXT_DEG * 2..EXT_DEG * 3].try_into().unwrap();
@@ -224,10 +226,6 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
 
     let prod_offset = ctx_ptr_u32 + CONTEXT_ARR_BASE_LEN as u32;
     for i in 0..num_prod_spec {
-        let [max_round]: [u32; 1] = exec_state
-            .vm_read(NATIVE_AS, prod_offset + i)
-            .map(|x: F| x.as_canonical_u32());
-
         let start = calculate_3d_ext_idx(
             prod_specs_inner_inner_len,
             prod_specs_inner_len,
@@ -266,10 +264,6 @@ unsafe fn execute_e12_impl<F: PrimeField32, CTX: ExecutionCtxTrait>(
 
     let logup_offset = ctx_ptr_u32 + CONTEXT_ARR_BASE_LEN as u32 + num_prod_spec;
     for i in 0..num_logup_spec {
-        // read max_round
-        let [max_round]: [u32; 1] = exec_state
-            .vm_read(NATIVE_AS, logup_offset + i)
-            .map(|x: F| x.as_canonical_u32());
         let start = calculate_3d_ext_idx(
             logup_specs_inner_inner_len,
             logup_specs_inner_len,

--- a/extensions/native/recursion/tests/sumcheck.rs
+++ b/extensions/native/recursion/tests/sumcheck.rs
@@ -103,7 +103,7 @@ fn build_test_program<C: Config>(builder: &mut Builder<C>) {
 
     let ctx: Array<C, Usize<C::N>> = builder.dyn_array(ctx_u32s.len());
     for (idx, n) in ctx_u32s.into_iter().enumerate() {
-        builder.set(&ctx, idx, Usize::from(n as usize));
+        builder.set(&ctx, idx, Usize::from(n));
     }
 
     #[rustfmt::skip]
@@ -197,9 +197,9 @@ fn build_test_program<C: Config>(builder: &mut Builder<C>) {
     }
 
     let r_evals = once(eval_acc)
-        .chain(p_evals.into_iter())
-        .chain(logup_p_evals.into_iter())
-        .chain(logup_q_evals.into_iter())
+        .chain(p_evals)
+        .chain(logup_p_evals)
+        .chain(logup_q_evals)
         .collect::<Vec<_>>();
 
     let next_layer_evals: Array<C, Ext<C::F, C::EF>> = builder.dyn_array(r_evals.len());


### PR DESCRIPTION
- Reduce context operations related to `max_rounds`